### PR TITLE
Add a CI job to check dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,37 @@ jobs:
                 path: ./docker.tar.gz
                 retention-days: 3
 
+    build-deps-check:
+        name: Check build system dependencies
+        runs-on: ubuntu-latest
+        needs: build-env
+
+        steps:
+          - name: Check out the repository
+            uses: actions/checkout@v2
+
+          - name: Download build-env
+            uses: actions/download-artifact@v2
+            with:
+                name: build-env
+                path: artifacts
+
+          - name: Import docker image
+            run: docker load --input artifacts/docker.tar.gz
+
+          - name: Verify dependencies of all install targets
+            run: |
+                docker run -v $(pwd):/reaveros ghcr.io/griwes/reaveros-build-env:${{ github.sha }} bash -c '
+                    set -e
+                    set -o pipefail
+                    cd /build
+                    for target in $(make help | grep -- -install | sed "s/\.\.\. //")
+                    do
+                        rm -rf install/{images,kernels,loaders,sysroots,userspace}
+                        make ${target} -j$(nproc)
+                    done
+                '
+
     image-build:
         name: Build OS image
         runs-on: ubuntu-latest
@@ -115,7 +146,7 @@ jobs:
     automerge:
         name: Auto-merge if PR is automatic
         runs-on: ubuntu-latest
-        needs: [image-build, unit-tests]
+        needs: [build-deps-check, image-build, unit-tests]
 
         if: github.event_name == 'pull_request'
 


### PR DESCRIPTION
For now this will probably be the longest job in the workflow, other than the one preparing a build environment, but the goal is to run it in parallel with jobs that will, *eventually*, actually start a VM and test that the build image reaches a certain reasonable point, and then (one day) actually performs some hosted tests; at that point, this being separate will, hopefully, save some time.