### PR TITLE
Add a missing include in thorn.

### DIFF
--- a/toolchain/thorn/context.cpp
+++ b/toolchain/thorn/context.cpp
@@ -16,6 +16,7 @@
 
 #include "context.h"
 
+#include <algorithm>
 #include <random>
 
 namespace thorn


### PR DESCRIPTION
Looks like GCC 12 made some stdlib headers include less things, so include them correctly.