### PR TITLE
Use clang and lld-link to build the UEFI loader directly.

### DIFF
--- a/cmake/target_functions.cmake
+++ b/cmake/target_functions.cmake
@@ -17,7 +17,7 @@ function(reaveros_add_aggregate_targets _suffix)
         _reaveros_add_target_maybe_tests(all-${architecture}${_suffix})
     endforeach()
 
-    set(_modes freestanding hosted)
+    set(_modes uefi freestanding hosted)
     if (REAVEROS_ENABLE_UNIT_TESTS)
         list(APPEND _modes tests)
     endif()

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021-2022 Michał 'Griwes' Dominiak
+ * Copyright © 2021-2023 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libraries/boot-protocol/component.cmake
+++ b/libraries/boot-protocol/component.cmake
@@ -1,4 +1,4 @@
 set(REAVEROS_COMPONENT_ARCHITECTURES ${REAVEROS_ARCHITECTURES})
 set(REAVEROS_COMPONENT_INSTALL_PATH [=[sysroots/${_architecture}-${_mode}]=])
-set(REAVEROS_COMPONENT_MODES freestanding tests)
+set(REAVEROS_COMPONENT_MODES uefi freestanding tests)
 set(REAVEROS_COMPONENT_DEPENDS [=[library-rosestd-${_mode}-${_architecture}]=])

--- a/libraries/rosestd/component.cmake
+++ b/libraries/rosestd/component.cmake
@@ -1,4 +1,4 @@
 set(REAVEROS_COMPONENT_ARCHITECTURES ${REAVEROS_ARCHITECTURES})
 set(REAVEROS_COMPONENT_INSTALL_PATH [=[sysroots/${_architecture}-${_mode}]=])
-set(REAVEROS_COMPONENT_MODES freestanding hosted tests)
+set(REAVEROS_COMPONENT_MODES uefi freestanding hosted tests)
 set(REAVEROS_COMPONENT_DEPENDS_HOSTED [=[library-rosert-hosted-${_architecture}]=])

--- a/libraries/rosestd/include/CMakeLists.txt
+++ b/libraries/rosestd/include/CMakeLists.txt
@@ -31,7 +31,11 @@ set(includes
 )
 
 if (NOT REAVEROS_ENABLE_UNIT_TESTS)
-    set(install_dir ${CMAKE_INSTALL_PREFIX}/usr/include/rosestd/v0)
+    if (NOT REAVEROS_IS_UEFI)
+        set(install_dir ${CMAKE_INSTALL_PREFIX}/usr/include/rosestd/v0)
+    else()
+        set(install_dir ${CMAKE_INSTALL_PREFIX}/usr/include)
+    endif()
 else()
     set(install_dir ${CMAKE_INSTALL_PREFIX}/usr/include/rosestd)
 endif()

--- a/libraries/rosestd/include/cstdint
+++ b/libraries/rosestd/include/cstdint
@@ -35,14 +35,20 @@
 
 __ROSESTD_OPEN
 
+#ifdef __ROSE_UEFI
+#define __ROSESTD_LONG long long
+#else
+#define __ROSESTD_LONG long
+#endif
+
 __ROSESTD_DEFINE_ALIASES(8, char);
 __ROSESTD_DEFINE_ALIASES(16, short);
 __ROSESTD_DEFINE_ALIASES(32, int);
-__ROSESTD_DEFINE_ALIASES(64, long);
+__ROSESTD_DEFINE_ALIASES(64, __ROSESTD_LONG);
 __ROSESTD_DEFINE_ALIASES(128, __int128);
 
-using intptr_t = long;
-using uintptr_t = unsigned long;
+using intptr_t = __ROSESTD_LONG;
+using uintptr_t = unsigned __ROSESTD_LONG;
 static_assert(sizeof(intptr_t) == sizeof(void *), "");
 static_assert(sizeof(uintptr_t) == sizeof(void *), "");
 

--- a/loaders/uefi/CMakeLists.txt
+++ b/loaders/uefi/CMakeLists.txt
@@ -6,12 +6,6 @@ file(GLOB_RECURSE sources
     *.cpp
 )
 
-set_source_files_properties(
-    ${sources}
-    PROPERTIES
-        COMPILE_FLAGS "-DHAVE_USE_MS_ABI -fshort-wchar"
-)
-
 file(GLOB asm_sources
     CONFIGURE_DEPENDS
     *.asm
@@ -25,30 +19,18 @@ set_source_files_properties(
         COMPILE_FLAGS -integrated-as
 )
 
-add_executable(loader-uefi-elf
+add_executable(loader-uefi
     ${asm_sources}
     ${sources}
 )
 
-target_link_libraries(loader-uefi-elf
+target_link_libraries(loader-uefi
     ${CMAKE_SYSROOT}/usr/lib/librosestd.a
 )
 
-set(linker_script ${CMAKE_CURRENT_SOURCE_DIR}/loader.lds)
-
-set_target_properties(loader-uefi-elf
+set_target_properties(loader-uefi
     PROPERTIES
-        LINK_FLAGS "-Wl,-T,${linker_script} -Bsymbolic -Wl,-Map=loader.map -fpie"
-        LINK_DEPENDS ${linker_script}
-)
-
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/loader-uefi
-    DEPENDS loader-uefi-elf
-
-    COMMAND
-        ${BINUTILS_OBJCOPY} -j .text -j .sdata -j .data -j .dynamic -j .dynsym -j .rel -j .rela -j .reloc --target=efi-app-x86_64
-            $<TARGET_FILE:loader-uefi-elf>
-            ${CMAKE_BINARY_DIR}/loader-uefi
+        LINKER_LANGUAGE CXX
 )
 
 add_custom_target(loader-uefi-pe ALL DEPENDS ${CMAKE_BINARY_DIR}/loader-uefi)

--- a/loaders/uefi/component.cmake
+++ b/loaders/uefi/component.cmake
@@ -1,5 +1,5 @@
 set(REAVEROS_COMPONENT_ARCHITECTURES ${REAVEROS_ARCHITECTURES})
 set(REAVEROS_COMPONENT_INSTALL_PATH [=[loaders/uefi-${_architecture}]=])
-set(REAVEROS_COMPONENT_MODES freestanding)
+set(REAVEROS_COMPONENT_MODES uefi)
 set(REAVEROS_COMPONENT_SKIP_MODE_NAME TRUE)
-set(REAVEROS_COMPONENT_DEPENDS [=[all-${_architecture}-freestanding-libraries]=])
+set(REAVEROS_COMPONENT_DEPENDS [=[all-${_architecture}-uefi-libraries]=])

--- a/loaders/uefi/crt0.asm
+++ b/loaders/uefi/crt0.asm
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Michał 'Griwes' Dominiak
+ * Copyright © 2023 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ _start:
     mov rdi, 0x0
     mov dword ptr [rdi], 0xaeaeaeae
 
-    lea rdi, [rip + image_base]
-    lea rsi, [rip + _DYNAMIC]
+    //lea rdi, [rip + image_base]
+    //lea rsi, [rip + _DYNAMIC]
 
     push rcx
     push rdx

--- a/loaders/uefi/efi/efi.h
+++ b/loaders/uefi/efi/efi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Michał 'Griwes' Dominiak
+ * Copyright © 2021, 2023 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,14 @@ struct acpi_information
 };
 
 acpi_information find_acpi_root();
+
+struct image_info
+{
+    void * image_base;
+    std::size_t image_size;
+};
+
+image_info get_image_info();
 
 struct memory_map
 {

--- a/loaders/uefi/efi/filesystem.cpp
+++ b/loaders/uefi/efi/filesystem.cpp
@@ -226,4 +226,14 @@ file_buffer load_file(const path & p)
 
     return { size, std::move(buffer) };
 }
+
+image_info get_image_info()
+{
+    image_info ret;
+
+    ret.image_base = loaded_image->image_base;
+    ret.image_size = loaded_image->image_size;
+
+    return ret;
+}
 }

--- a/maintenance/update-toolchain
+++ b/maintenance/update-toolchain
@@ -39,7 +39,6 @@ source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 git_toolchain_elementss=(
     cmake
     llvm
-    llvm_binutils_extra
     dosfstools
 )
 

--- a/toolchain/config.cmake
+++ b/toolchain/config.cmake
@@ -8,11 +8,6 @@ set(REAVEROS_LLVM_TAG llvmorg-16.0.6)
 set(REAVEROS_LLVM_PATTERN llvmorg-[0-9]+\.[0-9]+\.[0-9]+)
 set(REAVEROS_LLVM_EXCLUDE llvmorg-.*-init)
 
-set(REAVEROS_LLVM_BINUTILS_EXTRA_REPO git://sourceware.org/git/binutils-gdb.git)
-set(REAVEROS_LLVM_BINUTILS_EXTRA_TAG binutils-2_36_1)
-set(REAVEROS_LLVM_BINUTILS_EXTRA_PATTERN binutils-[0-9]+_[0-9]+_[0-9]+)
-set(REAVEROS_LLVM_BINUTILS_EXTRA_EXCLUDE "")
-
 set(REAVEROS_DOSFSTOOLS_REPO https://github.com/dosfstools/dosfstools)
 set(REAVEROS_DOSFSTOOLS_TAG v4.2)
 set(REAVEROS_DOSFSTOOLS_PATTERN v[0-9]+\.[0-9]+)

--- a/toolchain/files/amd64-freestanding.cmake.in
+++ b/toolchain/files/amd64-freestanding.cmake.in
@@ -11,7 +11,6 @@ set(CMAKE_SYSROOT @REAVEROS_BINARY_DIR@/install/sysroots/amd64-freestanding)
 set(CMAKE_EXE_LINKER_FLAGS "--sysroot=${CMAKE_SYSROOT} -L${CMAKE_SYSROOT}/usr/lib -nostartfiles")
 
 set(CMAKE_OBJCOPY ${tools}/llvm-objcopy)
-set(BINUTILS_OBJCOPY ${tools}/x86_64-w64-mingw32-objcopy)
 
 set(CMAKE_ASM_COMPILER ${tools}/clang)
 set(CMAKE_ASM_FLAGS "-masm=intel -fPIC")

--- a/toolchain/files/amd64-uefi.cmake.in
+++ b/toolchain/files/amd64-uefi.cmake.in
@@ -1,0 +1,55 @@
+set(CMAKE_SYSTEM_NAME ReaverOS)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+
+set(REAVEROS_IS_FREESTANDING TRUE)
+set(REAVEROS_IS_UEFI TRUE)
+
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+set(triple x86_64-windows)
+
+set(tools @REAVEROS_BINARY_DIR@/install/toolchain/llvm/bin)
+
+set(CMAKE_SYSROOT @REAVEROS_BINARY_DIR@/install/sysroots/amd64-uefi)
+set(CMAKE_EXE_LINKER_FLAGS
+    "--target=${triple} --sysroot=${CMAKE_SYSROOT} -L${CMAKE_SYSROOT}/usr/lib -nostartfiles \
+    -nostdlib -fuse-ld=lld-link -Wl,-subsystem:efi_application -Wl,-entry:efi_main")
+
+set(CMAKE_OBJCOPY ${tools}/llvm-objcopy)
+
+set(CMAKE_ASM_COMPILER ${tools}/clang)
+set(CMAKE_ASM_FLAGS "-masm=intel --target=${triple} --sysroot=${CMAKE_SYSROOT}")
+
+set(CMAKE_C_COMPILER ${tools}/clang)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILE_FLAGS
+    "-ffreestanding -fno-stack-protector -D__ROSE_FREESTANDING -D__ROSE_UEFI \
+    -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-avx -mno-red-zone -mno-stack-arg-probe \
+    -Wall -Wextra -Wpedantic -Werror -Wno-unused-const-variable \
+    --target=${triple} -isystem ${CMAKE_SYSROOT}/usr/include"
+)
+
+set(CMAKE_C_COMPILE_OBJECT
+    "<CMAKE_C_COMPILER> ${CMAKE_C_COMPILE_FLAGS} <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>"
+)
+
+set(CMAKE_C_STANDARD @REAVEROS_C_STANDARD@)
+set(CMAKE_C_EXTENSIONS OFF)
+
+set(CMAKE_CXX_COMPILER ${tools}/clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILE_FLAGS
+    "-ffreestanding -fno-rtti -fno-exceptions -fno-stack-protector -D__ROSE_FREESTANDING -D__ROSE_UEFI \
+    -mno-sse -mno-sse2 -mno-sse3 -mno-sse4 -mno-avx -mno-red-zone -mno-stack-arg-probe \
+    -Wall -Wextra -Wpedantic -Werror -Wno-unused-const-variable \
+    --target=${triple} -isystem ${CMAKE_SYSROOT}/usr/include"
+)
+
+set(CMAKE_CXX_COMPILE_OBJECT
+    "<CMAKE_CXX_COMPILER> ${CMAKE_CXX_COMPILE_FLAGS} <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>"
+)
+
+set(CMAKE_CXX_STANDARD @REAVEROS_CXX_STANDARD@)
+set(CMAKE_CXX_EXTENSIONS OFF)
+

--- a/toolchain/llvm.cmake
+++ b/toolchain/llvm.cmake
@@ -123,33 +123,6 @@ ExternalProject_Add(toolchain-llvm
 reaveros_add_ep_prune_target(toolchain-llvm)
 reaveros_add_ep_fetch_tag_target(toolchain-llvm)
 
-if ("amd64" IN_LIST REAVEROS_ARCHITECTURES AND "uefi" IN_LIST REAVEROS_LOADERS)
-    ExternalProject_Add(toolchain-llvm-binutils-extra
-        GIT_REPOSITORY ${REAVEROS_LLVM_BINUTILS_EXTRA_REPO}
-        GIT_TAG ${REAVEROS_LLVM_BINUTILS_EXTRA_TAG}
-        GIT_SHALLOW TRUE
-        UPDATE_DISCONNECTED 1
-
-        STEP_TARGETS install
-
-        INSTALL_DIR ${REAVEROS_BINARY_DIR}/install/toolchain/llvm
-
-        ${_REAVEROS_CONFIGURE_HANDLED_BY_BUILD}
-
-        CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-docs --disable-nls --disable-werror
-            --disable-gdb
-            --target=x86_64-w64-mingw32
-            "CC=${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}"
-            "CXX=${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}"
-        BUILD_COMMAND $(MAKE) MAKEINFO=true
-        INSTALL_COMMAND $(MAKE) MAKEINFO=true install
-    )
-    reaveros_add_ep_prune_target(toolchain-llvm-binutils-extra)
-    reaveros_add_ep_fetch_tag_target(toolchain-llvm-binutils-extra)
-
-    add_dependencies(toolchain-llvm-install toolchain-llvm-binutils-extra-install)
-endif()
-
 # install compiler-rt to the appropriate sysroots
 string(REGEX REPLACE "llvmorg-(([0-9]+)\.[0-9]+\.[0-9])+(-.*)?" "\\2" _llvm_version "${REAVEROS_LLVM_TAG}")
 ExternalProject_Get_Property(toolchain-llvm BINARY_DIR)


### PR DESCRIPTION
This allows entirely dropping a binutils dependency, which is great.